### PR TITLE
Decrease CPU usage by adding some SOE live server settings

### DIFF
--- a/linux/localOptions.cfg
+++ b/linux/localOptions.cfg
@@ -312,6 +312,9 @@ chroniclesQuestorSilverTokenNumModifier=2
 gcwPointBonus=5.0
 gcwTokenBonus=5.0
 
+triggerVolumeSystem=2
+numberOfMoveObjectLists=10
+
 ##Controls what to enable disable on frog
 [CharacterBuilder]
 builderEnabled=1


### PR DESCRIPTION
The original leak contained the config files SOE used for live servers. This pull request adds two config settings from the live server configs which are different from the default setting used currently:

> triggerVolumeSystem=2

This changes the trigger volumes to use a Sphere Grid instead of a Sphere Tree. The Sphere Grid is significantly faster than the Sphere Tree for Trigger Volumes.

> numberOfMoveObjectLists=10

Currently all moving objects have their own sphere and the sphere of all their trigger volumes updated every frame. With this setting, all moving objects are evenly distributed among the number of Move Lists specified in the config setting while only 1 Move List is updated every frame. With a setting of 10, this will update every moving object within at most 10 frames.
 
Note that SOE used a ground Frame Rate limit of 10 on their live servers (current is set to default which is 5). I omitted this change from the PR since it may not be desired for a local test server environment.

These changes have significantly reduced CPU usage in both idle and heavy load situations on my VM.
