### PR TITLE
Added config enable for SE Goggles

### DIFF
--- a/linux/localOptions.cfg
+++ b/linux/localOptions.cfg
@@ -258,6 +258,7 @@ veteranDebugTriggerAll=1
 veteranDebugEnableOverrideAccountAge=9999
 flashSpeederReward=true
 combatUpgradeReward=true
+seGogglesReward=true
 
 #Events
 ##Turn on or off Lifeday


### PR DESCRIPTION
Option to enable or disable SE Goggles bestowed by the /segoggles command