### PR TITLE
Feature/space rare loot system

### DIFF
--- a/linux/servercommon.cfg
+++ b/linux/servercommon.cfg
@@ -47,3 +47,4 @@ environmentVariable=LD_LIBRARY_PATH+=/usr/java/lib:/usr/java/lib/server:./
 .include "nodes.cfg"
 .include "rare_loot.cfg"
 .include "space_gcw.cfg"
+.include "space_rare_loot.cfg"

--- a/linux/space_rare_loot.cfg
+++ b/linux/space_rare_loot.cfg
@@ -1,0 +1,40 @@
+[SpaceRareLoot]
+
+# Base percent chance for an eligible space kill to award a rare loot chest.
+# Set to 0 or remove this key to disable space rare loot.
+baseChance=0
+
+# Cooldown in seconds between chest awards per player.
+# 0 disables the cooldown.
+delaySeconds=3600
+
+# Enables testing/debug messages for rare loot eligibility and award checks.
+debugMessages=false
+
+# QA/testing option: treats lower-tier targets as same-tier for eligibility/chance behavior.
+qaTreatLowerTargetAsSameTier=false
+
+# Relative quality weights used after a chest award succeeds.
+# These do not need to total 100, but these defaults represent 70/25/5.
+rareChance=70
+exceptionalChance=25
+legendaryChance=5
+
+# For higher-tier targets, shift this many points per tier out of Rare chance
+# and into Exceptional/Legendary according to the ratios below.
+higherTierQualityShift=5
+
+# Portion of shifted Rare chance that becomes Exceptional chance.
+higherTierExceptionalShiftRatio=0.80
+
+# Portion of shifted Rare chance that becomes Legendary chance.
+higherTierLegendaryShiftRatio=0.20
+
+# Maximum number of target tiers above the player that can apply quality shifting.
+higherTierQualityShiftMaxTiers=3
+
+# Stat scaling applied when creating rare space loot items.
+# Rare is below baseline, Exceptional is baseline, Legendary is above baseline.
+rareScale=0.50
+exceptionalScale=1.00
+legendaryScale=1.50


### PR DESCRIPTION
Added a space rare loot system.

This system is disabled by default. I have added a default config file, but if you are adding this to an existing server, create/paste the following into:

space_rare_loot.cfg

Then add space_rare_loot.cfg as an include in servercommon.cfg.

Below is a sample config with Space Rare Loot disabled.

[SpaceRareLoot]

# Base percent chance for an eligible space kill to award a rare loot chest.
# Set to 0 or remove this key to disable space rare loot.
baseChance=0

# Cooldown in seconds between chest awards per player.
# 0 disables the cooldown.
delaySeconds=3600

# Enables testing/debug messages for rare loot eligibility and award checks.
debugMessages=false

# QA/testing option: treats lower-tier targets as same-tier for eligibility/chance behavior.
qaTreatLowerTargetAsSameTier=false

# Relative quality weights used after a chest award succeeds.
# These do not need to total 100, but these defaults represent 70/25/5.
rareChance=70
exceptionalChance=25
legendaryChance=5

# For higher-tier targets, shift this many points per tier out of Rare chance
# and into Exceptional/Legendary according to the ratios below.
higherTierQualityShift=5

# Portion of shifted Rare chance that becomes Exceptional chance.
higherTierExceptionalShiftRatio=0.80

# Portion of shifted Rare chance that becomes Legendary chance.
higherTierLegendaryShiftRatio=0.20

# Maximum number of target tiers above the player that can apply quality shifting.
higherTierQualityShiftMaxTiers=3

# Stat scaling applied when creating rare space loot items.
# Rare is below baseline, Exceptional is baseline, Legendary is above baseline.
rareScale=0.50
exceptionalScale=1.00
legendaryScale=1.50